### PR TITLE
DB initialization and migration functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ cd test
 go test -v
 ```
 
+## Database Initialization/Migration
+
+To initialize a fresh database:
+```
+go run main.go -init
+```
+
+If there are new schema changes (edits to `models.go`), migrate the database to reflect these:
+```
+go run main.go -migrate
+```
+
 ## Potential Issues
 If the server does not shut down correctly, it could still be running on port 5000 and you'll need to kill that process. Add this to your bashrc:
 ```

--- a/main.go
+++ b/main.go
@@ -9,14 +9,16 @@ import (
 
 func main() {
   const listenAddress = "0.0.0.0:9090"
-  log.Printf("Roomz API Service starting on %v", listenAddress)
   lis, err := net.Listen("tcp", listenAddress)
   if err != nil {
     log.Fatalf("Failed to listen: %v", err)
   }
 
   server := server.NewRoomzApiServer()
-  if err := server.Serve(lis); err != nil {
-    log.Fatalf("Failed to serve: %v", err)
+  if server != nil {
+    log.Printf("Roomz API Service starting on %v", listenAddress)
+    if err := server.Serve(lis); err != nil {
+      log.Fatalf("Failed to serve: %v", err)
+    }
   }
 }

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -1,0 +1,115 @@
+// Package migration manages database initializations or migrations.
+package migration
+
+import (
+  "fmt"
+
+  "github.com/ABFranco/roomz-api-server/models"
+  "gorm.io/gorm"
+)
+
+// Init checks for the existence of all expected database tables, and if non-existant,
+// automatically creates them.
+func Init(db *gorm.DB) {
+  migrator := db.Migrator()
+  fmt.Printf("Initializing the db: %s...\n", migrator.CurrentDatabase())
+
+  // Verify the existence of all models & create if not already existed.
+  if !migrator.HasTable(&models.Guest{}) {
+    fmt.Println("The database does not have a guest table. Creating...")
+    if err := migrator.CreateTable(&models.Guest{}); err != nil {
+      fmt.Println("Failed to create guest table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.Account{}) {
+    fmt.Println("The database does not have a account table. Creating...")
+    if err := migrator.CreateTable(&models.Account{}); err != nil {
+      fmt.Println("Failed to create account table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.RoomUser{}) {
+    fmt.Println("The database does not have a room user table. Creating...")
+    if err := migrator.CreateTable(&models.RoomUser{}); err != nil {
+      fmt.Println("Failed to create room user table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.User{}) {
+    fmt.Println("The database does not have a user table. Creating...")
+    if err := migrator.CreateTable(&models.User{}); err != nil {
+      fmt.Println("Failed to create user table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.Message{}) {
+    fmt.Println("The database does not have a message table. Creating...")
+    if err := migrator.CreateTable(&models.Message{}); err != nil {
+      fmt.Println("Failed to create message table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.MessageType{}) {
+    fmt.Println("The database does not have a message type table. Creating...")
+    if err := migrator.CreateTable(&models.MessageType{}); err != nil {
+      fmt.Println("Failed to create message type table...")
+      return
+    }
+    // Initialize 2 rows in MessageType table.
+    tx := db.Begin()
+    chatroomMessageType := models.MessageType{
+      MessageType: "chatroom",
+    }
+    if tx.Create(&chatroomMessageType).Error != nil {
+      fmt.Println("Failed to create chatroom message type!")
+      return
+    }
+    activityMessageType := models.MessageType{
+      MessageType: "activity",
+    }
+    if tx.Create(&activityMessageType).Error != nil {
+      fmt.Println("Failed to create activity message type!")
+      return
+    }
+    tx.Commit()
+  }
+  if !migrator.HasTable(&models.RoomJoinRequest{}) {
+    fmt.Println("The database does not have a room join request table. Creating...")
+    if err := migrator.CreateTable(&models.RoomJoinRequest{}); err != nil {
+      fmt.Println("Failed to create room join request table...")
+      return
+    }
+  }
+  if !migrator.HasTable(&models.Room{}) {
+    fmt.Println("The database does not have a room table. Creating...")
+    if err := migrator.CreateTable(&models.Room{}); err != nil {
+      fmt.Println("Failed to create room table...")
+      return
+    }
+  }
+  fmt.Printf("Database %s successfully initialized!", migrator.CurrentDatabase())
+}
+
+// Migrate automatically migrates the Postgres DB for any schema changes (i.e. new structs or 
+// altered structs in models.go).
+func Migrate(db *gorm.DB) {
+  migrator := db.Migrator()
+  fmt.Printf("Auto-Migrating db %s for any schema changes...\n", migrator.CurrentDatabase())
+  fmt.Println("NOTE: Auto-migration will not automatically delete columns.")
+  
+  if err := migrator.AutoMigrate(
+    &models.Guest{},
+    &models.Account{},
+    &models.RoomUser{},
+    &models.User{},
+    &models.Message{},
+    &models.MessageType{},
+    &models.RoomJoinRequest{},
+    &models.Room{},
+  ); err != nil {
+    fmt.Printf("Error auto-migrating db  %s: %v", migrator.CurrentDatabase(), err)
+    return
+  }
+  fmt.Printf("Database %s successfully migrated!", migrator.CurrentDatabase())
+}

--- a/server/api.go
+++ b/server/api.go
@@ -529,7 +529,7 @@ func (r *roomzApiService) EnterChatRoom(req *rpb.EnterChatRoomRequest, chatStrea
 // SendChatMessage creates a new Message object which is sent on the Room chat
 // channel.
 func (r *roomzApiService) SendChatMessage(ctx context.Context, req *rpb.ChatMessage) (*rpb.SendChatMessageResponse, error) {
-  log.Printf(":CreateAccount: Received data=%v", req)
+  log.Printf(":SendChatMessage: Received data=%v", req)
   resp := &rpb.SendChatMessageResponse{}
   tx := r.RDB.Begin()
 

--- a/server/server.go
+++ b/server/server.go
@@ -8,6 +8,7 @@ import (
   "os"
 
   rpb "github.com/ABFranco/roomz-proto/go_proto"
+  "github.com/ABFranco/roomz-api-server/migration"
   "github.com/ABFranco/roomz-api-server/models"
   "google.golang.org/grpc"
   "gorm.io/driver/postgres"
@@ -18,6 +19,12 @@ const (
   host     = "localhost"
   port     = 5432
   dbname   = "roomz"
+)
+
+var (
+  testMode = flag.Bool("test", false, "indicate running the RAS in test mode.")
+  dbInit = flag.Bool("init", false, "initialize the Postgres DB")
+  dbMigrate = flag.Bool("migrate", false, "migrate the Postgres DB")
 )
 
 type roomUserChatChannel struct {
@@ -59,9 +66,15 @@ func NewRoomzApiServer() *grpc.Server {
     panic(err)
   }
 
-  // Check if running in "test" mode.
-  testMode := flag.Bool("test", false, "indicate testmode")
   flag.Parse()
+  if *dbInit {
+    migration.Init(db)
+    return nil
+  }
+  if *dbMigrate {
+    migration.Migrate(db)
+    return nil
+  }
   if *testMode {
     fmt.Printf("Running test mode!!\n")
   }


### PR DESCRIPTION
Well, not so bad!

Please reference https://gorm.io/docs/migration.html for any of the gorm-related code.

`-init` will work if the `roomz` DB is completely dropped. The user must first create the db manually in PGadmin or locally using `psql`, but this flag will automatically populate your tables for you.

`-migrate` works for altered models/structs, it will automatically add/edit the columns for you. If one is deleting a column, we must manually do this in Pgadmin.

I tested both commands thoroughly and ran through some full integration examples, and everything is clean. We can rollback if not. I do not expect y'all to delete your DB's and work off this, but honestly since I've dropped my DB, things are moving faster 👀

@hridayeshvjoshi for your avatar table, since it's a new struct, you will need to add your object to the `Init` and `Migrate` functions here.